### PR TITLE
Convert console errors to logs. Not actual error messages.

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -2,5 +2,5 @@ const app = require('./server')
 const config = require('./config')
 
 app.listen(config.port, function () {
-  console.error(`${app.name} listening on port ${config.port} [${app.get('env')}]`)
+  console.log(`${app.name} listening on port ${config.port} [${app.get('env')}]`)
 })

--- a/lib/storage/fs.js
+++ b/lib/storage/fs.js
@@ -9,7 +9,7 @@ class FS extends require('./base') {
   constructor () {
     super()
     this.directory = path.resolve(config.fs.directory)
-    console.error(`Saving files to local filesystem at ${this.directory}`)
+    console.log(`Saving files to local filesystem at ${this.directory}`)
     if (!config.fs.directory) console.error('Set NPM_REGISTER_FS_DIRECTORY to change directory')
   }
 

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -12,7 +12,7 @@ class S3 extends require('./base') {
     this.client = Promise.promisifyAll(require('s3').createClient({
       s3Client: Promise.promisifyAll(new AWS.S3({ params: { Bucket: config.s3.bucket } }))
     }))
-    console.error(`Saving files to s3 bucket ${config.s3.bucket}`)
+    console.log(`Saving files to s3 bucket ${config.s3.bucket}`)
   }
 
   get (Key) {


### PR DESCRIPTION
Per issue #64, converting errors to logs to notify user with correct context.