### PR TITLE
Allow PR tests to run in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,6 @@ stages:
       - type: cache-restore
         key: npm-register-{{checksum "package.json"}}
       - run: |
-          if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-            echo "AWS_SECRET_ACCESS_KEY must be set. Pull requests may only be run by the owner of the repository"
-            exit 1
-          fi
           set -x
           export REDIS_URL=localhost:6379
           node -v

--- a/test/dist_tags.js
+++ b/test/dist_tags.js
@@ -14,8 +14,10 @@ function bearer (token) {
   }
 }
 
+const storageMethods = process.env.CI ? ['fs'] : ['fs', 's3']
+
 describe('dist-tags', () => {
-  ['fs', 's3'].forEach(storage => {
+  storageMethods.forEach(storage => {
     describe(storage, () => {
       let token
       before(co.wrap(function * () {

--- a/test/dist_tags.js
+++ b/test/dist_tags.js
@@ -7,6 +7,7 @@ let expect = require('unexpected')
 
 // make sure this user is in the htpasswd file
 const testUser = {name: 'test', password: 'test'}
+const storageBackends = process.env.AWS_SECRET_ACCESS_KEY ? ['fs', 's3'] : ['fs']
 
 function bearer (token) {
   return function (request) {
@@ -14,10 +15,8 @@ function bearer (token) {
   }
 }
 
-const storageMethods = process.env.CI ? ['fs'] : ['fs', 's3']
-
 describe('dist-tags', () => {
-  storageMethods.forEach(storage => {
+  storageBackends.forEach(storage => {
     describe(storage, () => {
       let token
       before(co.wrap(function * () {

--- a/test/init.js
+++ b/test/init.js
@@ -3,6 +3,10 @@ const path = require('path')
 
 process.env.NPM_REGISTER_FS_DIRECTORY = path.join(__dirname, '../tmp')
 
+if (!process.env.AWS_SECRET_ACCESS_KEY) {
+  console.warn(`WARN: S3 Configuration not available - falling back to only testing the filesystem backend`)
+}
+
 if (!fs.existsSync('./tmp/htpasswd')) {
   fs.outputFileSync('./tmp/htpasswd', 'test:$2y$05$ZhGKbrjyUbSbiMUeYeRUKOXPKzs9./NIZHsycrQkUKIj1Z2VybqdK\n')
 }

--- a/test/install.js
+++ b/test/install.js
@@ -14,9 +14,9 @@ process.env.NPM_CONFIG_REGISTRY = registry
 let dir
 tmp.setGracefulCleanup()
 
-const storageMethods = process.env.CI ? ['fs'] : ['fs', 's3']
+const storageBackends = process.env.AWS_SECRET_ACCESS_KEY ? ['fs', 's3'] : ['fs']
 
-storageMethods.forEach(storage => {
+storageBackends.forEach(storage => {
   describe(storage, () => {
     before(() => {
       let Storage = require('../lib/storage/' + storage)

--- a/test/install.js
+++ b/test/install.js
@@ -14,7 +14,9 @@ process.env.NPM_CONFIG_REGISTRY = registry
 let dir
 tmp.setGracefulCleanup()
 
-;['fs', 's3'].forEach(storage => {
+const storageMethods = process.env.CI ? ['fs'] : ['fs', 's3']
+
+storageMethods.forEach(storage => {
   describe(storage, () => {
     before(() => {
       let Storage = require('../lib/storage/' + storage)

--- a/test/invalidate.js
+++ b/test/invalidate.js
@@ -6,11 +6,11 @@ let config = require('../lib/config')
 describe('invalidate', () => {
   // TODO: test this functionality. right now this is just executing
   describe('POST /-/invalidate/array-union', () => {
-    before(function () {
+    beforeEach(function () {
       if (!redis) return this.skip()
       config.auth.write = false
     })
-    after(() => {
+    afterEach(() => {
       config.auth.write = true
     })
     it('does not fail', async () => {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,3 @@
 --require test/init.js
 --timeout 60000
+--exit

--- a/test/packages.js
+++ b/test/packages.js
@@ -25,9 +25,9 @@ function bearer (token) {
   }
 }
 
-const storageMethods = process.env.CI ? ['fs'] : ['fs', 's3']
+const storageBackends = process.env.AWS_SECRET_ACCESS_KEY ? ['fs', 's3'] : ['fs']
 
-storageMethods.forEach(storage => {
+storageBackends.forEach(storage => {
   describe(storage, () => {
     let token
     before(co.wrap(function * () {

--- a/test/packages.js
+++ b/test/packages.js
@@ -25,7 +25,9 @@ function bearer (token) {
   }
 }
 
-['fs', 's3'].forEach(storage => {
+const storageMethods = process.env.CI ? ['fs'] : ['fs', 's3']
+
+storageMethods.forEach(storage => {
   describe(storage, () => {
     let token
     before(co.wrap(function * () {

--- a/test/user.js
+++ b/test/user.js
@@ -14,7 +14,9 @@ function bearer (token) {
   }
 }
 
-['fs', 's3'].forEach(storage => {
+const storageMethods = process.env.CI ? ['fs'] : ['fs', 's3']
+
+storageMethods.forEach(storage => {
   describe(storage, () => {
     before(() => {
       let Storage = require('../lib/storage/' + storage)

--- a/test/user.js
+++ b/test/user.js
@@ -14,9 +14,9 @@ function bearer (token) {
   }
 }
 
-const storageMethods = process.env.CI ? ['fs'] : ['fs', 's3']
+const storageBackends = process.env.AWS_SECRET_ACCESS_KEY ? ['fs', 's3'] : ['fs']
 
-storageMethods.forEach(storage => {
+storageBackends.forEach(storage => {
   describe(storage, () => {
     before(() => {
       let Storage = require('../lib/storage/' + storage)


### PR DESCRIPTION
Hey there

Following on from the conversation on #94, I took a look at the different options for running the tests in CI.

There are a few different ways we could take it:

1. Rewrite the current tests to mock S3 completely.
In this situation the tests would still look like integration tests but wouldn't actually be testing the storage backend. 

2. Create new unit tests which mock s3, keep the existing integration tests.
note: the integration tests would still not be able to run on CI because they would require the decrypted secrets. If we believe there is value in keeping the integration tests (I do personally) this doesn't get us anywhere unless we introduce a dependency on the maintainers to test PRs. 

The plus side of this is we'd get unit tests - but it would require a decent amount of work to add them and doesn't seem strictly related to this problem (would be nice to have regardless)

3. Don't test S3 on pull requests, where secrets are unavailable, but do run all the other tests. 
In this scenario there would be a dependency on the maintainers to run the full suite of tests. This could be done locally or by moving the branch to jdxcode/npm-register where secrets would be decryptable by circle CI

---

The solution I've included for now is number 3. It's the simplest and unblocks the CI pipeline. Authors of PRs get some feedback on their PR and we are not in a less safe place than we are currently where none of the tests can run. 

Would love to get your thoughts on the above @dgautsch @jdxcode 