### PR TITLE
Changing Docker base image to alpine 3.7 to support ASYNC (node 8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.7
 MAINTAINER Jeff Dickey
 
 # Install NodeJS and node-gyp deps


### PR DESCRIPTION
The docker build is using a node.js version without ASYNC support and the application fails when the node server starts:

```
/srv/npm-register/lib/middleware/auth.js:4
async function doAuth (req, res, next) {
      ^^^^^^^^
SyntaxError: Unexpected token function
    at Object.exports.runInThisContext (vm.js:76:16)
    at Module._compile (module.js:528:28)
```

Updating the docker image from alpine 3.4 (node 6.7.0) to 3.7 (node 8.9.3) did the trick