### PR TITLE
Dockerfile: add permissions to volume location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,17 +19,20 @@ RUN addgroup -S register \
         -s /bin/bash \
         -h /srv/npm-register \
         -G register \
-        register
+        register \
+    && mkdir -p /srv/npm-register/src /srv/npm-register/data \
+    && chown -R register:register /srv/npm-register \
+    && chmod -R g+w /srv/npm-register
 
 # Deploy application
-COPY . /srv/npm-register
-WORKDIR /srv/npm-register
+COPY . /srv/npm-register/src
+WORKDIR /srv/npm-register/src
 RUN npm install \
     && chown -R register:register .
 
 # Share storage volume
-ENV NPM_REGISTER_FS_DIRECTORY /data
-VOLUME /data
+ENV NPM_REGISTER_FS_DIRECTORY /srv/npm-register/data
+VOLUME /srv/npm-register/data
 
 # Start application
 EXPOSE 3000


### PR DESCRIPTION
I have no idea how could this Dockerfile work at all. The volume is created under root user, that means nothing will be copied into volume, and default permission will be `root` which is obviously impossible to use it under user `register`. 

I've tried my best to make folders inside of `/data` and change permissions the way it's done now, and it wasn't working. Even those permissions were fine, creating sub-folders by `npm-register` brought `permission denied` error again. So I've decided to move content of homedir, to `/srv/npm-register/src` and data to `/srv/npm-register/data` and that finally started to work.

Closes #112 