### PR TITLE
Add support for `npm audit` command

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -84,6 +84,12 @@ async function get (name, etag) {
   }
 }
 
+async function post (path, body) {
+  let opts = Object.assign({body}, getRequestOpts())
+  let req = await HTTP.post(url.resolve(config.uplink.href, path), opts)
+  return req.body
+}
+
 function getTarball (name, filename) {
   return HTTP.stream(`${config.uplink.href}${name}/-/${filename}`, getRequestOpts())
 }
@@ -96,6 +102,7 @@ async function getLatest (name) {
 
 module.exports = {
   get: get,
+  post: post,
   getTarball,
   getLatest
 }

--- a/lib/routes/audit.js
+++ b/lib/routes/audit.js
@@ -1,0 +1,16 @@
+const r = module.exports = require('express').Router()
+const npm = require('../npm')
+const middleware = require('../middleware')
+const aw = require('./asyncawait')
+const bodyParser = require('body-parser')
+
+// forward audit requests to upstream
+r.post(
+  '/-/npm/v1/security/audits',
+  middleware.auth.read,
+  bodyParser.json({limit: '3mb'}),
+  aw(async function (req, res) {
+    const response = await npm.post(req.path, req.body)
+    res.send(response)
+  })
+)

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -2,6 +2,7 @@ let r = module.exports = require('express').Router()
 
 r.use(require('./ping'))
 r.use(require('./version'))
+r.use(require('./audit'))
 r.use(require('./auth'))
 r.use(require('./dist_tags'))
 r.use(require('./invalidate'))


### PR DESCRIPTION
Simply forwards the POST data to the upstream registry